### PR TITLE
Redundant types

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Types       | Description
 `non-empty-array` | Check whether a variable is of type array, and not empty
 `non-empty-list`  | Check that an array is a non-associative list, and not empty
 
+#### Redundant types
 You cannot declare a super-type and a sub-type in one union type declaration.
 
 Super-type | Sub-type

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Super-type | Sub-type
 `list[]`   | `non-empty-list`
 `non-empty-array` | `non-empty-list`
 
+```php
+use Realodix\Assert\Assert;
+
+public function setFoo($foo)
+{
+    Assert::type($foo, 'bool|false'); // Disallowed
+}
+```
+
 ## License
 
 This package is licensed using the [MIT License](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Types       | Description
 `non-empty-list`  | Check that an array is a non-associative list, and not empty
 
 #### Redundant types
-You cannot declare a super-type and a sub-type one union type declaration.
+You cannot declare a super-type and a sub-type one union type declarations.
 
 Super-type | Sub-type
 ---------- | -------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ use Realodix\Assert\Assert;
 
 public function setFoo($foo)
 {
-    Assert::type($foo, 'bool|false'); // Disallowed
+    // Disallowed because false is a type of bool
+    Assert::type($foo, 'bool|false');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Types       | Description
 `non-empty-list`  | Check that an array is a non-associative list, and not empty
 
 #### Redundant types
-You cannot declare a super-type and a sub-type one union type declarations.
+You cannot declare a super-type and a sub-type in union type declarations.
 
 Super-type | Sub-type
 ---------- | -------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Types       | Description
 `non-empty-list`  | Check that an array is a non-associative list, and not empty
 
 #### Redundant types
-You cannot declare a super-type and a sub-type in one union type declaration.
+You cannot declare a super-type and a sub-type one union type declaration.
 
 Super-type | Sub-type
 ---------- | -------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Super-type | Sub-type
 `bool`     | `true`, and  `false`
 `numeric`  | `int`, and  `float`
 `array`    | `list[]`, `bool[]`, `string[]`, `int[]`, `float[]`, `object[]`, `float[]`, `non-empty-string`, and `non-empty-array`
-
+`string`   | `non-empty-string`
 
 ## License
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -124,7 +124,6 @@ class Helper
         }
 
         // Duplicate types
-        // Tidak boleh ada 2 nama tipe atau lebih dalam satu deklarasi yang sama.
         $actualTypesCount = \count($types);
         $expectedTypesCount = \count(array_intersect_key($types, array_unique(array_map('strtolower', $types))));
         if ($expectedTypesCount < $actualTypesCount) {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -121,11 +121,11 @@ class Helper
         }
 
         // Duplicate types
-        $actualTypesCount = \count($types);
-        $expectedTypesCount = \count(
+        $actTypesCount = \count($types);
+        $expTypesCount = \count(
             array_intersect_key($types, array_unique(array_map('strtolower', $types)))
         );
-        if ($expectedTypesCount < $actualTypesCount) {
+        if ($expTypesCount < $actTypesCount) {
             return true;
         }
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -116,9 +116,9 @@ class Helper
                 (\in_array('list[]', $types)
                 || (\in_array('non-empty-list', $types)))
             || \in_array('list[]', $types) &&
-                (\in_array('non-empty-list', $types))
+                \in_array('non-empty-list', $types)
             || \in_array('string', $types) &&
-                (\in_array('non-empty-string', $types))
+                \in_array('non-empty-string', $types)
         ) {
             return true;
         }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -125,7 +125,7 @@ class Helper
 
         // Tidak boleh ada 2 nama tipe atau lebih dalam satu deklarasi yang sama.
         $actualTypesCount = \count($types);
-        $expectedTypesCount = \count(array_unique(array_map('strtolower',$types)));
+        $expectedTypesCount = \count(array_unique(array_map('strtolower', $types)));
         if ($expectedTypesCount < $actualTypesCount) {
             return true;
         }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -117,6 +117,8 @@ class Helper
                 || (\in_array('non-empty-list', $types)))
             || \in_array('list[]', $types) &&
                 (\in_array('non-empty-list', $types))
+            || \in_array('string', $types) &&
+                (\in_array('non-empty-string', $types))
         ) {
             return true;
         }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -99,8 +99,7 @@ class Helper
                 || \in_array('string', $types)
                 || \in_array('bool', $types))
             || \in_array('bool', $types) &&
-                (\in_array('true', $types)
-                || \in_array('false', $types))
+                (\in_array('true', $types) || \in_array('false', $types))
             || \in_array('numeric', $types) &&
                 (\in_array('int', $types)
                 || \in_array('float', $types))

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -113,19 +113,18 @@ class Helper
                 || \in_array('non-empty-array', $types)
                 || \in_array('non-empty-list', $types))
             || \in_array('non-empty-array', $types) &&
-                (\in_array('list[]', $types)
-                || (\in_array('non-empty-list', $types)))
-            || \in_array('list[]', $types) &&
-                \in_array('non-empty-list', $types)
-            || \in_array('string', $types) &&
-                \in_array('non-empty-string', $types)
+                (\in_array('list[]', $types) || (\in_array('non-empty-list', $types)))
+            || \in_array('list[]', $types) && \in_array('non-empty-list', $types)
+            || \in_array('string', $types) && \in_array('non-empty-string', $types)
         ) {
             return true;
         }
 
         // Duplicate types
         $actualTypesCount = \count($types);
-        $expectedTypesCount = \count(array_intersect_key($types, array_unique(array_map('strtolower', $types))));
+        $expectedTypesCount = \count(
+            array_intersect_key($types, array_unique(array_map('strtolower', $types)))
+        );
         if ($expectedTypesCount < $actualTypesCount) {
             return true;
         }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -125,7 +125,7 @@ class Helper
 
         // Tidak boleh ada 2 nama tipe atau lebih dalam satu deklarasi yang sama.
         $actualTypesCount = \count($types);
-        $expectedTypesCount = \count(array_unique($types));
+        $expectedTypesCount = \count(array_unique(array_map('strtolower',$types)));
         if ($expectedTypesCount < $actualTypesCount) {
             return true;
         }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -91,6 +91,7 @@ class Helper
             $types = explode('|', $types);
         }
 
+        // Redundant types
         if (\in_array('scalar', $types) &&
                 (\in_array('numeric', $types)
                 || \in_array('int', $types)
@@ -123,6 +124,7 @@ class Helper
             return true;
         }
 
+        // Duplicate types
         // Tidak boleh ada 2 nama tipe atau lebih dalam satu deklarasi yang sama.
         $actualTypesCount = \count($types);
         $expectedTypesCount = \count(array_unique(array_map('strtolower', $types)));

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -126,7 +126,7 @@ class Helper
         // Duplicate types
         // Tidak boleh ada 2 nama tipe atau lebih dalam satu deklarasi yang sama.
         $actualTypesCount = \count($types);
-        $expectedTypesCount = \count(array_unique(array_map('strtolower', $types)));
+        $expectedTypesCount = \count(array_intersect_key($types, array_unique(array_map('strtolower', $types))));
         if ($expectedTypesCount < $actualTypesCount) {
             return true;
         }

--- a/tests/Multiple/UnionTypesTest.php
+++ b/tests/Multiple/UnionTypesTest.php
@@ -70,9 +70,9 @@ class UnionTypesTest extends TestCase
      * Each name-resolved type may only occur once. Types like A|B|A or A&B&A
      * result in an error.
      *
-     * @dataProvider duplicateMembersProvider
+     * @dataProvider duplicateTypesProvider
      */
-    public function testDuplicateMembers($types, $value)
+    public function testDuplicateTypes($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(
@@ -87,9 +87,9 @@ class UnionTypesTest extends TestCase
     }
 
     /**
-     * @dataProvider redundantMembersProvider
+     * @dataProvider redundantTypesProvider
      */
-    public function testRedundantMembers($types, $value)
+    public function testRedundantTypes($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(

--- a/tests/Multiple/UnionTypesTest.php
+++ b/tests/Multiple/UnionTypesTest.php
@@ -78,30 +78,28 @@ class UnionTypesTest extends TestCase
         $this->expectExceptionMessage(
             'Duplicate type names in the same declaration is not allowed.'
         );
-        Assert::type($value, $types);
+
+        if (\is_array($types)) {
+            Assert::type([$value], $types);
+        } else {
+            Assert::type($value, $types);
+        }
     }
 
     /**
-     * @dataProvider duplicateMembersProvider
+     * @dataProvider redundantMembersProvider
      */
-    public function testDuplicateMembersWithArrayInput($types, $value)
+    public function testRedundantMembers($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(
             'Duplicate type names in the same declaration is not allowed.'
         );
-        Assert::type([$value], $types);
-    }
 
-    /**
-     * @dataProvider duplicateMembersWithArrayInputProvider
-     */
-    public function testDuplicateMembersWithArrayInput2($types, $value)
-    {
-        $this->expectException(\ErrorException::class);
-        $this->expectExceptionMessage(
-            'Duplicate type names in the same declaration is not allowed.'
-        );
-        Assert::type($value, $types);
+        if (\is_array($types)) {
+            Assert::type([$value], $types);
+        } else {
+            Assert::type($value, $types);
+        }
     }
 }

--- a/tests/Multiple/UnionTypesTest.php
+++ b/tests/Multiple/UnionTypesTest.php
@@ -80,9 +80,9 @@ class UnionTypesTest extends TestCase
         );
 
         if (\is_array($types)) {
-            Assert::type([$value], $types);
-        } else {
             Assert::type($value, $types);
+        } else {
+            Assert::type([$value], $types);
         }
     }
 
@@ -97,9 +97,9 @@ class UnionTypesTest extends TestCase
         );
 
         if (\is_array($types)) {
-            Assert::type([$value], $types);
-        } else {
             Assert::type($value, $types);
+        } else {
+            Assert::type([$value], $types);
         }
     }
 }

--- a/tests/Multiple/UnionTypesTest.php
+++ b/tests/Multiple/UnionTypesTest.php
@@ -11,18 +11,20 @@ class UnionTypesTest extends TestCase
     use UnionTypesTestProvider;
 
     /**
+     * @test
      * @dataProvider validTypesProvider
      */
-    public function testValidTypes($types, $value)
+    public function validTypes($types, $value)
     {
         Assert::type($value, $types);
         $this->addToAssertionCount(1);
     }
 
     /**
+     * @test
      * @dataProvider invalidTypesProvider
      */
-    public function testInvalidTypes($types, $value)
+    public function invalidTypes($types, $value)
     {
         $this->expectException(TypeErrorException::class);
         Assert::type($value, $types);
@@ -35,9 +37,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider allowedSymbolProvider
      */
-    public function testAllowedSymbol($types, $value)
+    public function allowedSymbol($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage("Only '|' symbol that allowed.");
@@ -45,9 +48,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider symbolsMustBeBetweenTypeNamesProvider
      */
-    public function testSymbolsMustBeBetweenTypeNames($types, $value)
+    public function symbolsMustBeBetweenTypeNames($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage('Symbols must be between type names.');
@@ -55,9 +59,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider duplicateSymbolsProvider
      */
-    public function testDuplicateSymbols($types, $value)
+    public function duplicateSymbols($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage('Duplicate symbols are not allowed.');
@@ -65,9 +70,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider duplicateTypesProvider
      */
-    public function testDuplicateTypes($types, $value)
+    public function duplicateTypes($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(
@@ -78,9 +84,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider duplicateTypesProvider
      */
-    public function testDuplicateTypesWithArrayTypeInput($types, $value)
+    public function duplicateTypesWithTypeInputAsAnArray($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(
@@ -92,9 +99,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider redundantTypesProvider
      */
-    public function testRedundantTypes($types, $value)
+    public function redundantTypes($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(
@@ -105,9 +113,10 @@ class UnionTypesTest extends TestCase
     }
 
     /**
+     * @test
      * @dataProvider redundantTypesProvider
      */
-    public function testRedundantTypesWithArrayTypeInput($types, $value)
+    public function redundantTypesWithTypeInputAsAnArray($types, $value)
     {
         $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage(

--- a/tests/Multiple/UnionTypesTest.php
+++ b/tests/Multiple/UnionTypesTest.php
@@ -65,11 +65,6 @@ class UnionTypesTest extends TestCase
     }
 
     /**
-     * Reject duplicate type names
-     *
-     * Each name-resolved type may only occur once. Types like A|B|A or A&B&A
-     * result in an error.
-     *
      * @dataProvider duplicateTypesProvider
      */
     public function testDuplicateTypes($types, $value)
@@ -79,11 +74,21 @@ class UnionTypesTest extends TestCase
             'Duplicate type names in the same declaration is not allowed.'
         );
 
-        if (\is_array($types)) {
-            Assert::type($value, $types);
-        } else {
-            Assert::type([$value], $types);
-        }
+        Assert::type($value, $types);
+    }
+
+    /**
+     * @dataProvider duplicateTypesProvider
+     */
+    public function testDuplicateTypesWithArrayTypeInput($types, $value)
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage(
+            'Duplicate type names in the same declaration is not allowed.'
+        );
+
+        $types = explode('|', $types);
+        Assert::type($value, $types);
     }
 
     /**
@@ -96,10 +101,20 @@ class UnionTypesTest extends TestCase
             'Duplicate type names in the same declaration is not allowed.'
         );
 
-        if (\is_array($types)) {
-            Assert::type($value, $types);
-        } else {
-            Assert::type([$value], $types);
-        }
+        Assert::type($value, $types);
+    }
+
+    /**
+     * @dataProvider redundantTypesProvider
+     */
+    public function testRedundantTypesWithArrayTypeInput($types, $value)
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage(
+            'Duplicate type names in the same declaration is not allowed.'
+        );
+
+        $types = explode('|', $types);
+        Assert::type($value, $types);
     }
 }

--- a/tests/Multiple/UnionTypesTest.php
+++ b/tests/Multiple/UnionTypesTest.php
@@ -92,4 +92,16 @@ class UnionTypesTest extends TestCase
         );
         Assert::type([$value], $types);
     }
+
+    /**
+     * @dataProvider duplicateMembersWithArrayInputProvider
+     */
+    public function testDuplicateMembersWithArrayInput2($types, $value)
+    {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage(
+            'Duplicate type names in the same declaration is not allowed.'
+        );
+        Assert::type($value, $types);
+    }
 }

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -70,7 +70,7 @@ trait UnionTypesTestProvider
         return [
             ['bool|bool', true],
             ['bool|string|bool', true],
-            // ['int|string|INT', 1],
+            ['int|string|INT', 1],
 
             ['bool|boolean', true],
             ['float|double', 1.23],

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -65,7 +65,7 @@ trait UnionTypesTestProvider
         ];
     }
 
-    public function duplicateMembersProvider()
+    public function duplicateTypesProvider()
     {
         return [
             ['bool|bool', true],
@@ -78,7 +78,7 @@ trait UnionTypesTestProvider
         ];
     }
 
-    public function redundantMembersProvider()
+    public function redundantTypesProvider()
     {
         return [
             ['scalar|numeric', 123],

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -85,6 +85,8 @@ trait UnionTypesTestProvider
             ['numeric|int', 123],
             ['numeric|float', 123],
 
+            ['string|non-empty-string', 'string'],
+
             ['array|bool[]', []],
             ['array|string[]', []],
             ['array|int[]', []],

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -90,6 +90,7 @@ trait UnionTypesTestProvider
             ['array|float[]', []],
             ['array|object[]', []],
             ['array|list[]', []],
+            // ...
         ];
     }
 

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -86,7 +86,12 @@ trait UnionTypesTestProvider
             ['numeric|float', 123],
 
             ['string|non-empty-string', 'string'],
+        ];
+    }
 
+    public function duplicateMembersWithArrayInputProvider()
+    {
+        return [
             ['array|bool[]', []],
             ['array|string[]', []],
             ['array|int[]', []],

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -75,7 +75,12 @@ trait UnionTypesTestProvider
             ['bool|boolean', true],
             ['float|double', 1.23],
             ['int|integer', 123],
+        ];
+    }
 
+    public function redundantMembersProvider()
+    {
+        return [
             ['scalar|numeric', 123],
             ['scalar|int', 123],
             ['scalar|float', 123],
@@ -87,12 +92,7 @@ trait UnionTypesTestProvider
             ['numeric|float', 123],
 
             ['string|non-empty-string', 'string'],
-        ];
-    }
 
-    public function duplicateMembersWithArrayInputProvider()
-    {
-        return [
             ['array|bool[]', []],
             ['array|string[]', []],
             ['array|int[]', []],

--- a/tests/Multiple/UnionTypesTestProvider.php
+++ b/tests/Multiple/UnionTypesTestProvider.php
@@ -70,6 +70,7 @@ trait UnionTypesTestProvider
         return [
             ['bool|bool', true],
             ['bool|string|bool', true],
+            // ['int|string|INT', 1],
 
             ['bool|boolean', true],
             ['float|double', 1.23],


### PR DESCRIPTION
Union types does not allow redundant class types. However, it is important to note that this only applies to a few special special types only. 

- [x] `string|non-empty-string`

**V1**
- [ ] Each name-resolved type may only occur once. Types like `int|string|INT` result in an error.
- [x] If `bool ` is used, `false` cannot be used additionally.
- [ ] If `object` is used, `class` types cannot be used additionally.
- [ ] If `iterable` is used, `array` and `Traversable` cannot be used additionally.

**V2**
- [x] `bool|false` is not allowed because false is a type of `bool`.
- [ ] `object` cannot be used with a `class` name because all class objects are of type object too.
- [ ] `iterable` cannot be used with `array` or `Traversable` because iterable is a union type `array|Traversable` already.
- [ ] Class names can be used even if one extends another.


**Reference**
- https://wiki.php.net/rfc/union_types_v2
- https://php.watch/versions/8.0/union-types